### PR TITLE
fix: upgrade crd-ref-docs from v0.0.7 to v0.3.0

### DIFF
--- a/image/chaos-mesh.dev-reference/Dockerfile
+++ b/image/chaos-mesh.dev-reference/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18
+FROM golang:1.25
 LABEL org.opencontainers.image.source=https://github.com/STRRL/chaos-mesh.dev
 
 RUN apt-get update && \ 

--- a/image/chaos-mesh.dev-reference/Dockerfile
+++ b/image/chaos-mesh.dev-reference/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update && \
     apt-get install asciidoctor -y && \
     rm -rf /var/lib/apt/lists/*
 
-RUN go install github.com/elastic/crd-ref-docs@v0.0.7
+RUN go install github.com/elastic/crd-ref-docs@v0.3.0
 
 RUN mkdir -p /playground
 WORKDIR /playground


### PR DESCRIPTION
Closes #4

## Changes
- Upgrade `crd-ref-docs` from v0.0.7 to v0.3.0
- Upgrade base image from `golang:1.18` to `golang:1.25` (required by crd-ref-docs v0.3.0, which specifies `go 1.25.0` in go.mod)

## Verification
- Docker image builds successfully with `golang:1.25` + `crd-ref-docs@v0.3.0`
- `crd-ref-docs` binary installs and runs correctly inside the container