### PR TITLE
fix: use force_orphan to prevent gh-pages history bloat

### DIFF
--- a/.github/workflows/godoc-daily-regenerate.yaml
+++ b/.github/workflows/godoc-daily-regenerate.yaml
@@ -6,31 +6,40 @@ on:
   - cron: "0 22 * * *"
 
 jobs:
-  godoc-for-branches:
-    strategy:
-      max-parallel: 1
-      fail-fast: false
-      matrix:
-        active-branches:
-          - master
-          - release-2.1
-          - release-2.0
+  godoc-regenerate:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: generate godoc
+      with:
+        ref: gh-pages
+        path: gh-pages-current
+    - name: setup git user as github-action
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "<41898282+github-actions[bot]@users.noreply.github.com>"
+    - name: generate godoc for all branches
       run: |
         mkdir -p out/godoc
-        docker run -v $(pwd)/out/godoc:/playground/out ghcr.io/strrl/chaos-mesh.dev-godoc:latest ${{ matrix.active-branches }}
-    - name: change permission of these files
+        for branch in master release-2.1 release-2.0; do
+          echo "Generating godoc for $branch..."
+          docker run -v $(pwd)/out/godoc:/playground/out ghcr.io/strrl/chaos-mesh.dev-godoc:latest "$branch"
+        done
+    - name: prepare publish directory
       run: |
         sudo chmod -R 755 out
+        # Copy existing gh-pages content (reference, static files) and overlay new godoc
+        mkdir -p publish
+        cp -r gh-pages-current/* publish/ 2>/dev/null || true
+        rm -rf publish/.git
+        # Replace godoc directory with freshly generated content
+        rm -rf publish/godoc
+        cp -r out/godoc publish/godoc
     - name: publish to gh-pages
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: out/godoc/${{ matrix.active-branches }}
-        destination_dir: godoc/${{ matrix.active-branches }}
+        publish_dir: ./publish
         disable_nojekyll: true
         user_name: 'github-actions[bot]'
         user_email: 'github-actions[bot]@users.noreply.github.com'
+        force_orphan: true

--- a/.github/workflows/manually-generate-godoc.yaml
+++ b/.github/workflows/manually-generate-godoc.yaml
@@ -8,24 +8,34 @@ on:
         default: master
 
 jobs:
-  godoc: 
+  godoc:
     name: "Generate godoc for: ${{ github.event.inputs.branchOrTag }}"
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+        ref: gh-pages
+        path: gh-pages-current
     - name: generate godoc
       run: |
         mkdir -p out/godoc
         docker run -v $(pwd)/out/godoc:/playground/out ghcr.io/strrl/chaos-mesh.dev-godoc:latest ${{ github.event.inputs.branchOrTag }}
-    - name: change permission of these files
+    - name: prepare publish directory
       run: |
         sudo chmod -R 755 out
+        mkdir -p publish
+        cp -r gh-pages-current/* publish/ 2>/dev/null || true
+        rm -rf publish/.git
+        # Replace only the target branch godoc
+        rm -rf "publish/godoc/${{ github.event.inputs.branchOrTag }}"
+        mkdir -p publish/godoc
+        cp -r "out/godoc/${{ github.event.inputs.branchOrTag }}" "publish/godoc/${{ github.event.inputs.branchOrTag }}"
     - name: publish to gh-pages
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: out/godoc/${{ github.event.inputs.branchOrTag }}
-        destination_dir: godoc/${{ github.event.inputs.branchOrTag }}
+        publish_dir: ./publish
         disable_nojekyll: true
         user_name: 'github-actions[bot]'
         user_email: 'github-actions[bot]@users.noreply.github.com'
+        force_orphan: true

--- a/.github/workflows/manually-generate-reference.yaml
+++ b/.github/workflows/manually-generate-reference.yaml
@@ -8,24 +8,34 @@ on:
         default: master
 
 jobs:
-  godoc: 
+  godoc:
     name: "Generate API Reference for: ${{ github.event.inputs.branchOrTag }}"
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+        ref: gh-pages
+        path: gh-pages-current
     - name: generate API Reference
       run: |
         mkdir -p out/reference
         docker run -v $(pwd)/out/reference:/playground/out ghcr.io/strrl/chaos-mesh.dev-reference:latest ${{ github.event.inputs.branchOrTag }}
-    - name: change permission of these files
+    - name: prepare publish directory
       run: |
         sudo chmod -R 755 out
+        mkdir -p publish
+        cp -r gh-pages-current/* publish/ 2>/dev/null || true
+        rm -rf publish/.git
+        # Replace only the target branch reference
+        rm -rf "publish/reference/${{ github.event.inputs.branchOrTag }}"
+        mkdir -p publish/reference
+        cp -r "out/reference/${{ github.event.inputs.branchOrTag }}" "publish/reference/${{ github.event.inputs.branchOrTag }}"
     - name: publish to gh-pages
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: out/reference/${{ github.event.inputs.branchOrTag }}
-        destination_dir: reference/${{ github.event.inputs.branchOrTag }}
+        publish_dir: ./publish
         disable_nojekyll: true
         user_name: 'github-actions[bot]'
         user_email: 'github-actions[bot]@users.noreply.github.com'
+        force_orphan: true

--- a/.github/workflows/reference-daily-regenerate.yaml
+++ b/.github/workflows/reference-daily-regenerate.yaml
@@ -6,7 +6,8 @@ on:
   - cron: "0 22 * * *"
 
 jobs:
-  reference-for-branches:
+  generate-all:
+    runs-on: ubuntu-latest
     strategy:
       max-parallel: 1
       fail-fast: false
@@ -15,7 +16,6 @@ jobs:
           - master
           - release-2.1
           - release-2.0
-    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - name: setup git user as github-action
@@ -38,3 +38,4 @@ jobs:
         disable_nojekyll: true
         user_name: 'github-actions[bot]'
         user_email: 'github-actions[bot]@users.noreply.github.com'
+        force_orphan: true

--- a/.github/workflows/reference-daily-regenerate.yaml
+++ b/.github/workflows/reference-daily-regenerate.yaml
@@ -6,35 +6,39 @@ on:
   - cron: "0 22 * * *"
 
 jobs:
-  generate-all:
+  reference-regenerate:
     runs-on: ubuntu-latest
-    strategy:
-      max-parallel: 1
-      fail-fast: false
-      matrix:
-        active-branches:
-          - master
-          - release-2.1
-          - release-2.0
     steps:
     - uses: actions/checkout@v2
+      with:
+        ref: gh-pages
+        path: gh-pages-current
     - name: setup git user as github-action
       run: |
         git config user.name "github-actions[bot]"
         git config user.email "<41898282+github-actions[bot]@users.noreply.github.com>"
-    - name: generate API Reference
+    - name: generate API Reference for all branches
       run: |
         mkdir -p out/reference
-        docker run -v $(pwd)/out/reference:/playground/out ghcr.io/strrl/chaos-mesh.dev-reference:latest ${{ matrix.active-branches }}
-    - name: change permission of these files
+        for branch in master release-2.1 release-2.0; do
+          echo "Generating reference for $branch..."
+          docker run -v $(pwd)/out/reference:/playground/out ghcr.io/strrl/chaos-mesh.dev-reference:latest "$branch"
+        done
+    - name: prepare publish directory
       run: |
         sudo chmod -R 755 out
+        # Copy existing gh-pages content (godoc, static files) and overlay new reference
+        mkdir -p publish
+        cp -r gh-pages-current/* publish/ 2>/dev/null || true
+        rm -rf publish/.git
+        # Replace reference directory with freshly generated content
+        rm -rf publish/reference
+        cp -r out/reference publish/reference
     - name: publish to gh-pages
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: out/reference/${{ matrix.active-branches }}
-        destination_dir: reference/${{ matrix.active-branches }}
+        publish_dir: ./publish
         disable_nojekyll: true
         user_name: 'github-actions[bot]'
         user_email: 'github-actions[bot]@users.noreply.github.com'


### PR DESCRIPTION
## Problem

The gh-pages branch has accumulated **8289 commits**, making the repo **~5.5GB**. Every deploy adds a new commit to gh-pages history, which grows unbounded.

## Solution

All 4 deploy workflows now use `force_orphan: true` from `peaceiris/actions-gh-pages`. Each deploy:

1. Checks out the current gh-pages content
2. Generates new content (reference/godoc)
3. Merges with existing gh-pages files (preserving the other directory + static files like CNAME, _config.yml, README)
4. Force pushes as an **orphan commit** (no parent = no history accumulation)

### Changed workflows
- `reference-daily-regenerate.yaml` — collapsed matrix into single job, force_orphan
- `godoc-daily-regenerate.yaml` — collapsed matrix into single job, force_orphan  
- `manually-generate-reference.yaml` — force_orphan
- `manually-generate-godoc.yaml` — force_orphan

### After merging

Run `git gc` or re-clone to reclaim space. The gh-pages branch will only ever have 1 commit going forward.

### Note

After this PR is merged and one of the daily workflows runs, the repo size should drop dramatically on GitHub's next GC cycle.